### PR TITLE
무너지는 타일 버그 수정

### DIFF
--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public enum TileColor
 {
-    Black, White, Red, Blue, Yellow, Green, None
+    Black, White, Red, Blue, Yellow, Green, None, Transparent
 }
 
 public enum TileType
@@ -80,7 +80,7 @@ public class Tile : MonoBehaviour
             _data = value;
             if (spriteRenderer != null)
             {
-                spriteRenderer.sprite = SpriteDictionary.Instance.tileSpriteDictionary.GetSprite(_data);
+                // spriteRenderer.sprite = SpriteDictionary.Instance.tileSpriteDictionary.GetSprite(_data);
                 if (_data.type == TileType.Wall) spriteRenderer.sortingLayerName = "WallTile";
                 else spriteRenderer.sortingLayerName = "Tile";
             }
@@ -111,7 +111,7 @@ public class Tile : MonoBehaviour
 
     private void UpdateSprite()
     {
-	    spriteRenderer.sprite = SpriteDictionary.Instance.tileSpriteDictionary.GetSprite(_data);
+	    // spriteRenderer.sprite = SpriteDictionary.Instance.tileSpriteDictionary.GetSprite(_data);
         if (_data.type == TileType.Wall) spriteRenderer.sortingLayerName = "WallTile";
         else spriteRenderer.sortingLayerName = "Tile";
     }
@@ -134,7 +134,7 @@ public class Tile : MonoBehaviour
         int newColorIndex = (int)_data.color;
         if (_data.type == TileType.Wall)
             newColorIndex += 10;            
-        if (_data.type == TileType.None && _data.color == TileColor.None)
+        if (_data.color == TileColor.None)
             newColorIndex = -1;
         gameObject.GetComponent<Animator>().SetInteger("colorIndex", newColorIndex);    
     }


### PR DESCRIPTION
현재 타일의 이미지를 전부 애니메이션 클립으로 받아오기때문에 실질적으로 스프라이트를 쓰고있지 않은데, 스프라이트 참조에서 널익셉션이 반복됩니다.
타일 스프라이트를 읽어오는 두 부분을 주석처리했으며, 정상적으로 작동하는 것을 확인했습니다.
스프라이트 렌더러는 타일의 소팅레이어와 관련해서 사용하는 것 같지만 스프라이트는 앞으로도 사용할 일이 없을 것 같으니 이번 기회에 관련 메소드를 삭제하는 것이 좋아보입니다.

추가로, 지금 타일의 애니메이션 클립이 TileColor에만 영향을 받기 때문에 없는 타일과 투명한 타일의 구분이 불가능합니다. TileData를 바꿀 때 SetTileColor를 SetTileType보다 뒤에 배치하면 해결되기는 하지만, 깔끔하지 않고 혼동을 줄 여지가 있기 때문에 TileColor에 'Transparent'를 추가했습니다. 이제 TileColor.None은 없는 타일의 색에만 사용됩니다.
